### PR TITLE
fix: Add upgrade pod as an extra deployment

### DIFF
--- a/fuse_ignite_config.sh
+++ b/fuse_ignite_config.sh
@@ -3,7 +3,7 @@
 # Upstream Syndesis release
 git_syndesis="1.3.10"
 # Tag to create for the templates
-git_fuse_ignite_install="1.3.12"
+git_fuse_ignite_install="1.3.11"
 
 # Tags used for the productised images
 tag_server="1.0-17"

--- a/release.sh
+++ b/release.sh
@@ -215,10 +215,14 @@ create_templates() {
     sed -e "s#image:.*syndesis/syndesis-upgrade.*#image: $registry/$repository/fuse-ignite-upgrade:\${SYNDESIS_VERSION}#" \
         -i "" "$topdir/resources/fuse-ignite-oso.yml" "$topdir/resources/fuse-ignite-ocp.yml"
 
-    
-    echo "==== Patch templates with Upgrade container latest image"
-    echo $tag_upgrade
-    sed -e 's#syndesis/syndesis-upgrade:${SYNDESIS_VERSION}#'syndesis/syndesis-upgrade:$tag_upgrade#g -i "" "$topdir/resources/fuse-ignite-oso.yml" "$topdir/resources/fuse-ignite-ocp.yml"
+    echo "==== Create Upgrade Pod descriptor"
+
+    sed -e "s/{{[ ]*Tags.Ignite[ ]*}}/$fuse_ignite_tag/g" \
+        -e "s/{{[ ]*Tags.Ignite.Upgrade[ ]*}}/$tag_server/g" \
+        -e "s/{{[ ]*Docker.Registry[ ]*}}/$registry/g" \
+        -e "s/{{[ ]*Docker.Image.Repository[ ]*}}/$repository/g" \
+        $topdir/templates/fuse-ignite-upgrade.yml \
+        > $topdir/resources/fuse-ignite-upgrade.yml
 
     echo "==== Copy support SA"
     cp ../support/serviceaccount-as-oauthclient-restricted.yml \
@@ -238,7 +242,6 @@ create_templates() {
         -e "s/{{[ ]*Docker.Image.Repository[ ]*}}/$repository/g" \
         $topdir/templates/fuse-ignite-image-streams.yml \
         > $topdir/resources/fuse-ignite-image-streams.yml
-
 
     popd
 }

--- a/resources/fuse-ignite-image-streams.yml
+++ b/resources/fuse-ignite-image-streams.yml
@@ -12,7 +12,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/fuse7/fuse-ignite-server:1.0-8
+        name: registry.access.redhat.com/fuse7/fuse-ignite-server:1.0-17
       importPolicy:
         scheduled: true
       name: "1.3"
@@ -28,7 +28,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/fuse7/fuse-ignite-ui:1.0-6
+        name: registry.access.redhat.com/fuse7/fuse-ignite-ui:1.0-22
       importPolicy:
         scheduled: true
       name: "1.3"
@@ -44,7 +44,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/fuse7/fuse-ignite-meta:1.0-7
+        name: registry.access.redhat.com/fuse7/fuse-ignite-meta:1.0-15
       importPolicy:
         scheduled: true
       name: "1.3"
@@ -92,7 +92,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/fuse7/fuse-ignite-s2i:1.0-7
+        name: registry.access.redhat.com/fuse7/fuse-ignite-s2i:1.0-15
       importPolicy:
         scheduled: true
       name: "1.3"

--- a/resources/fuse-ignite-upgrade.yml
+++ b/resources/fuse-ignite-upgrade.yml
@@ -1,0 +1,29 @@
+kind: List
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: syndesis-upgrade-1.3.12
+  spec:
+    serviceAccountName: syndesis-operator
+    containers:
+    - name: upgrade
+      image: registry.access.redhat.com/fuse7/fuse-ignite-upgrade:1.0-17
+      env:
+        - name: SYNDESIS_UPGRADE_PROJECT
+          valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      imagePullPolicy: IfNotPresent
+      args:
+        - "--backup"
+        - "/opt/backup"
+      volumeMounts:
+      - mountPath: /opt/backup
+        subPath: backup
+        name: backup-dir
+    volumes:
+    - name: backup-dir
+      persistentVolumeClaim:
+        claimName: syndesis-db
+    restartPolicy: Never

--- a/templates/fuse-ignite-upgrade.yml
+++ b/templates/fuse-ignite-upgrade.yml
@@ -1,0 +1,29 @@
+kind: List
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: syndesis-upgrade-{{ Tags.Ignite }}
+  spec:
+    serviceAccountName: syndesis-operator
+    containers:
+    - name: upgrade
+      image: {{ Docker.Registry }}/{{ Docker.Image.Repository }}/fuse-ignite-upgrade:{{ Tags.Ignite.Upgrade }}
+      env:
+        - name: SYNDESIS_UPGRADE_PROJECT
+          valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      imagePullPolicy: IfNotPresent
+      args:
+        - "--backup"
+        - "/opt/backup"
+      volumeMounts:
+      - mountPath: /opt/backup
+        subPath: backup
+        name: backup-dir
+    volumes:
+    - name: backup-dir
+      persistentVolumeClaim:
+        claimName: syndesis-db
+    restartPolicy: Never


### PR DESCRIPTION
In Syndesis 1.3.10 the upgrade pod was includede with help of an template
that gets created when the Syndesis template is instantiated.
This approach has the disadvantage that the overall template (the outter)
has a fixed name and to create this the old template would need
to be replaced.
But it is the update itself who should replace.
That catch-22 can be only resolved if the start of the update pod
is not defined within the template it's supposed to be replaced.

Therefore a new file 'fuse-ignite-upgrade.yml' will be created in `resources/` .
This can be directly applied via `oc create -f fuse-ignite-upgrade.yml`
Therefor the documentation needs to be changed/updated.